### PR TITLE
Fixing entrypoint.sh uncommented line

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ else
     ROLLBAR_DEPLOY_ID=$(echo $RESPONSE | jq -r '.result.id')
 fi
 
-If not ROLLBAR_DEPLOY_ID something failed
+# If not ROLLBAR_DEPLOY_ID something failed
 if [[ "$ROLLBAR_DEPLOY_ID" == "null" ]]; then
     exit 1
 fi


### PR DESCRIPTION
The comment on line 41 was without the "#" and it was causing a error on Action runner:

```
/usr/bin/docker run --name d00b3367b96eb49b56469bae546a63f8c0c520_986621 --label d00b33 --workdir /github/workspace --rm -e CLOUDSDK_METRICS_ENVIRONMENT -e GOOGLE_APPLICATION_CREDENTIALS -e ROLLBAR_ACCESS_TOKEN -e INPUT_ENVIRONMENT -e INPUT_VERSION -e INPUT_STATUS -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/resources4vulnerable/resources4vulnerable":"/github/workspace" d00b33:67b96eb49b56469bae546a63f8c0c520  "devops" "$GITHUB_SHA" "started"
/entrypoint.sh: line 41: If: command not found
```