### PR TITLE
Remove deprecate set-output command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ if [[ "$ROLLBAR_DEPLOY_ID" == "null" ]]; then
 fi
 
 # Done
-echo "::set-output name=deploy_id::$ROLLBAR_DEPLOY_ID"
+echo "deploy_id=$ROLLBAR_DEPLOY_ID" >> $GITHUB_OUTPUT
 
 # Source map is provided
 if [[ "$SOURCE_MAP_FILES" ]]; then


### PR DESCRIPTION
## Description of the change

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Replace `set-output` as indicated in github documentation [here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter)

> Description here
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 