### PR TITLE
Improve error handling

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,7 @@ fi
 
 # If not ROLLBAR_DEPLOY_ID something failed
 if [[ "$ROLLBAR_DEPLOY_ID" == "null" ]]; then
+    echo "deploy_id not available"
     exit 1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,14 @@ RESPONSE=$(curl -X $METHOD https://api.rollbar.com/api/1/deploy/$DEPLOY_ID \
                 --form rollbar_username=$ROLLBAR_USERNAME \
                 --form local_username=$LOCAL_USERNAME)
 
+# If error code is not zero something failed
+ERROR_CODE=$(echo $RESPONSE | jq -r '.err')
+if [[ $ERROR_CODE -ne 0 ]]; then
+    ERROR_MESSAGE=$(echo $RESPONSE | jq -r '.message')
+    echo $ERROR_MESSAGE
+    exit 1
+fi
+
 # Get the deploy id depending on the response as they are different for POST and PATCH
 if [[ $METHOD == "POST" ]]; then
     ROLLBAR_DEPLOY_ID=$(echo $RESPONSE | jq -r '.data.deploy_id')


### PR DESCRIPTION
## Description of the change

This improves the error handling - giving better visibility of things that might have gone wrong. In particular:
- It now displays any error message returned in the response from Rollbar when the error code is not zero.
- It now displays a message if the `deploy_id` cannot be extracted from the response from Rollbar; whereas previously it just silently failed.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- There don't appear to be any lint rules, so I haven't done anything about that.
- There don't appear to be any tests, so I haven't done anything about that.

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 